### PR TITLE
Change map and data urls to the up-to-date ones

### DIFF
--- a/freifunk.net.json
+++ b/freifunk.net.json
@@ -43,13 +43,13 @@
   ],
   "nodeMaps": [
     {
-      "url": "https://ffmuc.net/map/",
+      "url": "https://map.ffmuc.net/",
       "interval": "1 minute",
       "technicalType": "meshviewer",
       "mapType": "geographical"
     },
     {
-      "url": "https://ffmuc.net/data/nodelist.json",
+      "url": "https://map.ffmuc.net/data/nodelist.json",
       "interval": "1 minute",
       "technicalType": "nodelist"
     }


### PR DESCRIPTION
https://ffmuc.net/map/ redicts to https://map.ffmuc.net/, doesn't need to be changed, but would be clearer.

The data in https://ffmuc.net/data/nodelist.json is outdated since 1st January 2017, new data is at https://map.ffmuc.net/data/nodelist.json

Since this file is used in many places, it should be up to date.

This repo has no issue page, so i directly created a pull request instead.