### PR TITLE
Change type from xml to rss

### DIFF
--- a/freifunk.net.json
+++ b/freifunk.net.json
@@ -30,7 +30,7 @@
         {
             "name": "ffmuc-blog",
             "category": "blog",
-            "type": "xml",
+            "type": "rss",
             "url": "https://ffmuc.net/feed.xml"
         }
     ],


### PR DESCRIPTION
It has been suggested that we should change the type from xml to rss in order to appear on the community news tab on freifunk.net